### PR TITLE
feat(Migration): Create migration 2 tables comune and province

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,9 +69,11 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
     <!--#endif-->
     <!--#if (UsePostgreSQL)-->
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.1" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.0.0" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="9.0.0" />
     <!--#endif-->
+    <PackageVersion Include="NetTopologySuite" Version="2.6.0" />
     <!--#if (UseSqlite)-->
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfcoreVersion)" />
     <!--#endif-->

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="MediatR.Contracts" />
+    <PackageReference Include="NetTopologySuite" />
   </ItemGroup>
 
 </Project>

--- a/src/Domain/Entities/Commune.cs
+++ b/src/Domain/Entities/Commune.cs
@@ -1,0 +1,23 @@
+using System;
+using NetTopologySuite.Geometries;
+
+namespace LotusDharma.Domain.Entities;
+
+public class Commune
+{
+    public string CommuneId { get; set; } = string.Empty;
+    public string ProvinceId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? NameNew { get; set; }
+    public string? Type { get; set; }
+    public double? AreaKm2 { get; set; }
+    public long? Population { get; set; }
+    public double? Longitude { get; set; }
+    public double? Latitude { get; set; }
+    public string? BeforeMerger { get; set; }
+    public MultiPolygon? Geometry { get; set; }
+    public DateTime? CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+    public Province Province { get; set; } = null!;
+}
+

--- a/src/Domain/Entities/Province.cs
+++ b/src/Domain/Entities/Province.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using NetTopologySuite.Geometries;
+
+namespace LotusDharma.Domain.Entities;
+
+public class Province
+{
+    public string ProvinceId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? NameNew { get; set; }
+    public string? AdministrativeCenter { get; set; }
+    public double? AreaKm2 { get; set; }
+    public long? Population { get; set; }
+    public double? Longitude { get; set; }
+    public double? Latitude { get; set; }
+    public string? BeforeMerger { get; set; }
+    public string? AdministrativeUnits { get; set; }
+    public MultiPolygon? Geometry { get; set; }
+    public DateTime? CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+    public ICollection<Commune> Communes { get; set; } = new List<Commune>();
+}
+

--- a/src/Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/Data/ApplicationDbContext.cs
@@ -15,8 +15,12 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
     public DbSet<TodoItem> TodoItems => Set<TodoItem>();
     
     public DbSet<Product> Products => Set<Product>();
-    
+
     public DbSet<Category> Categories => Set<Category>();
+
+    public DbSet<Province> Provinces => Set<Province>();
+
+    public DbSet<Commune> Communes => Set<Commune>();
 
     // Custom Identity entities
     public DbSet<User> Users => Set<User>();

--- a/src/Infrastructure/Data/Configurations/CommuneConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/CommuneConfiguration.cs
@@ -1,0 +1,78 @@
+using LotusDharma.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LotusDharma.Infrastructure.Data.Configurations;
+
+public class CommuneConfiguration : IEntityTypeConfiguration<Commune>
+{
+    public void Configure(EntityTypeBuilder<Commune> builder)
+    {
+        builder.ToTable("communes");
+        builder.HasKey(x => x.CommuneId);
+
+        builder.Property(x => x.CommuneId)
+            .HasColumnName("commune_id")
+            .HasColumnType("text")
+            .IsRequired();
+
+        builder.Property(x => x.ProvinceId)
+            .HasColumnName("province_id")
+            .HasColumnType("text")
+            .IsRequired();
+
+        builder.Property(x => x.Name)
+            .HasColumnName("name")
+            .HasColumnType("text")
+            .IsRequired();
+
+        builder.Property(x => x.NameNew)
+            .HasColumnName("name_new")
+            .HasColumnType("text");
+
+        builder.Property(x => x.Type)
+            .HasColumnName("type")
+            .HasColumnType("text");
+
+        builder.Property(x => x.AreaKm2)
+            .HasColumnName("area_km2")
+            .HasColumnType("double precision");
+
+        builder.Property(x => x.Population)
+            .HasColumnName("population")
+            .HasColumnType("bigint");
+
+        builder.Property(x => x.Longitude)
+            .HasColumnName("longitude")
+            .HasColumnType("double precision");
+
+        builder.Property(x => x.Latitude)
+            .HasColumnName("latitude")
+            .HasColumnType("double precision");
+
+        builder.Property(x => x.BeforeMerger)
+            .HasColumnName("before_merger")
+            .HasColumnType("text");
+
+        builder.Property(x => x.Geometry)
+            .HasColumnName("geometry")
+            .HasColumnType("geometry(MultiPolygon,4326)");
+
+        builder.Property(x => x.CreatedAt)
+            .HasColumnName("created_at")
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(x => x.UpdatedAt)
+            .HasColumnName("updated_at")
+            .HasColumnType("timestamp without time zone");
+
+        builder.HasIndex(x => x.ProvinceId)
+            .HasDatabaseName("IX_communes_province_id");
+
+        builder.HasOne(x => x.Province)
+            .WithMany(x => x.Communes)
+            .HasForeignKey(x => x.ProvinceId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}
+

--- a/src/Infrastructure/Data/Configurations/ProvinceConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/ProvinceConfiguration.cs
@@ -1,0 +1,74 @@
+using LotusDharma.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LotusDharma.Infrastructure.Data.Configurations;
+
+public class ProvinceConfiguration : IEntityTypeConfiguration<Province>
+{
+    public void Configure(EntityTypeBuilder<Province> builder)
+    {
+        builder.ToTable("provinces");
+        builder.HasKey(x => x.ProvinceId);
+
+        builder.Property(x => x.ProvinceId)
+            .HasColumnName("province_id")
+            .HasColumnType("text")
+            .IsRequired();
+
+        builder.Property(x => x.Name)
+            .HasColumnName("name")
+            .HasColumnType("text")
+            .IsRequired();
+
+        builder.Property(x => x.NameNew)
+            .HasColumnName("name_new")
+            .HasColumnType("text");
+
+        builder.Property(x => x.AdministrativeCenter)
+            .HasColumnName("administrative_center")
+            .HasColumnType("text");
+
+        builder.Property(x => x.AreaKm2)
+            .HasColumnName("area_km2")
+            .HasColumnType("double precision");
+
+        builder.Property(x => x.Population)
+            .HasColumnName("population")
+            .HasColumnType("bigint");
+
+        builder.Property(x => x.Longitude)
+            .HasColumnName("longitude")
+            .HasColumnType("double precision");
+
+        builder.Property(x => x.Latitude)
+            .HasColumnName("latitude")
+            .HasColumnType("double precision");
+
+        builder.Property(x => x.BeforeMerger)
+            .HasColumnName("before_merger")
+            .HasColumnType("text");
+
+        builder.Property(x => x.AdministrativeUnits)
+            .HasColumnName("administrative_units")
+            .HasColumnType("text");
+
+        builder.Property(x => x.Geometry)
+            .HasColumnName("geometry")
+            .HasColumnType("geometry(MultiPolygon,4326)");
+
+        builder.Property(x => x.CreatedAt)
+            .HasColumnName("created_at")
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(x => x.UpdatedAt)
+            .HasColumnName("updated_at")
+            .HasColumnType("timestamp without time zone");
+
+        builder.HasMany(x => x.Communes)
+            .WithOne(x => x.Province)
+            .HasForeignKey(x => x.ProvinceId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}
+

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -30,7 +30,7 @@ public static class DependencyInjection
         {
             options.AddInterceptors(sp.GetServices<ISaveChangesInterceptor>());
             // Sử dụng PostgreSQL
-            options.UseNpgsql(connectionString);
+            options.UseNpgsql(connectionString, npgsqlOptions => npgsqlOptions.UseNetTopologySuite());
         });
 
 #if (UseAspire)

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -23,6 +23,7 @@
     <!--#endif-->
     <!--#if (UsePostgreSQL)-->
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" />
     <!--#endif-->
     <!--#if (UseSqlite)-->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
@@ -37,6 +38,7 @@
     </PackageReference>
     <PackageReference Include="StackExchange.Redis" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
+    <PackageReference Include="NetTopologySuite" />
     <PackageReference Include="Google.Apis.Auth" />
   </ItemGroup>
 

--- a/src/Infrastructure/Migrations/20251127120000_AddProvincesAndCommunes.cs
+++ b/src/Infrastructure/Migrations/20251127120000_AddProvincesAndCommunes.cs
@@ -1,0 +1,56 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace LotusDharma.Infrastructure.Migrations;
+
+public partial class AddProvincesAndCommunes : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql(@"
+            CREATE TABLE IF NOT EXISTS provinces (
+                province_id text PRIMARY KEY,
+                name text NOT NULL,
+                name_new text,
+                administrative_center text,
+                area_km2 double precision,
+                population bigint,
+                longitude double precision,
+                latitude double precision,
+                before_merger text,
+                administrative_units text,
+                geometry geometry(MultiPolygon,4326),
+                created_at timestamp without time zone,
+                updated_at timestamp without time zone
+            );
+        ");
+
+        migrationBuilder.Sql(@"
+            CREATE TABLE IF NOT EXISTS communes (
+                commune_id text PRIMARY KEY,
+                province_id text NOT NULL,
+                name text NOT NULL,
+                name_new text,
+                type text,
+                area_km2 double precision,
+                population bigint,
+                longitude double precision,
+                latitude double precision,
+                before_merger text,
+                geometry geometry(MultiPolygon,4326),
+                created_at timestamp without time zone,
+                updated_at timestamp without time zone,
+                CONSTRAINT fk_communes_provinces FOREIGN KEY (province_id) REFERENCES provinces(province_id)
+            );
+        ");
+
+        migrationBuilder.Sql(@"
+            CREATE INDEX IF NOT EXISTS IX_communes_province_id ON communes(province_id);
+        ");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        // Intentionally empty: do not drop production geography tables.
+    }
+}
+

--- a/src/Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -4,6 +4,7 @@ using LotusDharma.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
@@ -377,6 +378,144 @@ namespace LotusDharma.Infrastructure.Migrations
                     b.HasIndex("UserId");
 
                     b.ToTable("UserTokens", (string)null);
+                });
+
+            modelBuilder.Entity("LotusDharma.Domain.Entities.Province", b =>
+                {
+                    b.Property<string>("ProvinceId")
+                        .HasColumnName("province_id")
+                        .HasColumnType("text");
+
+                    b.Property<string>("AdministrativeCenter")
+                        .HasColumnName("administrative_center")
+                        .HasColumnType("text");
+
+                    b.Property<string>("AdministrativeUnits")
+                        .HasColumnName("administrative_units")
+                        .HasColumnType("text");
+
+                    b.Property<double?>("AreaKm2")
+                        .HasColumnName("area_km2")
+                        .HasColumnType("double precision");
+
+                    b.Property<DateTime?>("CreatedAt")
+                        .HasColumnName("created_at")
+                        .HasColumnType("timestamp without time zone");
+
+                    b.Property<double?>("Latitude")
+                        .HasColumnName("latitude")
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("Longitude")
+                        .HasColumnName("longitude")
+                        .HasColumnType("double precision");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnName("name")
+                        .HasColumnType("text");
+
+                    b.Property<string>("NameNew")
+                        .HasColumnName("name_new")
+                        .HasColumnType("text");
+
+                    b.Property<long?>("Population")
+                        .HasColumnName("population")
+                        .HasColumnType("bigint");
+
+                    b.Property<string>("BeforeMerger")
+                        .HasColumnName("before_merger")
+                        .HasColumnType("text");
+
+                    b.Property<MultiPolygon>("Geometry")
+                        .HasColumnName("geometry")
+                        .HasColumnType("geometry(MultiPolygon,4326)");
+
+                    b.Property<DateTime?>("UpdatedAt")
+                        .HasColumnName("updated_at")
+                        .HasColumnType("timestamp without time zone");
+
+                    b.HasKey("ProvinceId");
+
+                    b.ToTable("provinces");
+                });
+
+            modelBuilder.Entity("LotusDharma.Domain.Entities.Commune", b =>
+                {
+                    b.Property<string>("CommuneId")
+                        .HasColumnName("commune_id")
+                        .HasColumnType("text");
+
+                    b.Property<DateTime?>("CreatedAt")
+                        .HasColumnName("created_at")
+                        .HasColumnType("timestamp without time zone");
+
+                    b.Property<double?>("Latitude")
+                        .HasColumnName("latitude")
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("Longitude")
+                        .HasColumnName("longitude")
+                        .HasColumnType("double precision");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnName("name")
+                        .HasColumnType("text");
+
+                    b.Property<string>("NameNew")
+                        .HasColumnName("name_new")
+                        .HasColumnType("text");
+
+                    b.Property<string>("BeforeMerger")
+                        .HasColumnName("before_merger")
+                        .HasColumnType("text");
+
+                    b.Property<double?>("AreaKm2")
+                        .HasColumnName("area_km2")
+                        .HasColumnType("double precision");
+
+                    b.Property<string>("ProvinceId")
+                        .HasColumnName("province_id")
+                        .HasColumnType("text");
+
+                    b.Property<long?>("Population")
+                        .HasColumnName("population")
+                        .HasColumnType("bigint");
+
+                    b.Property<MultiPolygon>("Geometry")
+                        .HasColumnName("geometry")
+                        .HasColumnType("geometry(MultiPolygon,4326)");
+
+                    b.Property<string>("Type")
+                        .HasColumnName("type")
+                        .HasColumnType("text");
+
+                    b.Property<DateTime?>("UpdatedAt")
+                        .HasColumnName("updated_at")
+                        .HasColumnType("timestamp without time zone");
+
+                    b.HasKey("CommuneId");
+
+                    b.HasIndex("ProvinceId");
+
+                    b.ToTable("communes");
+                });
+
+            modelBuilder.Entity("LotusDharma.Domain.Entities.Commune", b =>
+                {
+                    b.HasOne("LotusDharma.Domain.Entities.Province", "Province")
+                        .WithMany("Communes")
+                        .HasForeignKey("ProvinceId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("Province");
+                });
+
+            modelBuilder.Entity("LotusDharma.Domain.Entities.Province", b =>
+                {
+                    b.Navigation("Communes");
                 });
 
             modelBuilder.Entity("LotusDharma.Domain.Entities.Product", b =>

--- a/tasks/Backend/LD-0002.md
+++ b/tasks/Backend/LD-0002.md
@@ -1,152 +1,45 @@
-TITLE: Build Backend APIs for Provinces & Communes (GeoJSON + PostGIS)
+Task: Generate EF Core Migration for existing PostgreSQL/PostGIS schema.
 
-SECTION: Goal
-Implement backend APIs required for mapping provinces and communes of Vietnam, using PostgreSQL + PostGIS and .NET 9 Clean Architecture (Jason Taylor template). These APIs will serve data for the Next.js front-end map, including boundaries stored as MultiPolygon SRID 4326.
+Rules:
 
-SECTION: Scope
-Cursor must generate full vertical slices including:
+Do NOT drop or recreate provinces or communes tables.
 
-Domain entities
+The migration must only CREATE tables if they do NOT exist.
 
-EF configurations
+If tables already exist, migration must skip creation.
 
-Application DTOs
+Support geometry type: geometry(MultiPolygon,4326).
 
-CQRS Query + Handler
+Ensure entity configuration matches exact existing schema:
 
-Specification filters
+Table: provinces
 
-Mapping profiles
+Table: communes
 
-Minimal API endpoints
+Set all column types exactly as database:
 
-Geometry to GeoJSON serialization
+VARCHAR → text or character varying
 
-BBox queries
+BIGINT → bigint
 
-Parameter validation
+DOUBLE → double precision
 
-SECTION: Database Tables
+TIMESTAMP → timestamp without time zone
 
-TABLE provinces
-province_id (PK, string)
-name
-name_new
-administrative_center
-area_km2 (double)
-population (bigint)
-longitude (double)
-latitude (double)
-before_merger
-administrative_units
-geometry (MultiPolygon, SRID 4326)
-created_at
-updated_at
+For geometry column, use:
+builder.Property(x => x.Geometry).HasColumnType("geometry(MultiPolygon,4326)");
 
-TABLE communes
-commune_id (PK, string)
-province_id (FK → provinces)
-name
-name_new
-type
-area_km2 (double)
-population (bigint)
-longitude (double)
-latitude (double)
-before_merger
-geometry (MultiPolygon, SRID 4326)
-created_at
-updated_at
+Migration must be idempotent, safe to run multiple times, and must not overwrite existing data.
 
-SECTION: Required Endpoints
+Output:
 
-GET /api/provinces
-Parameters: search, includeGeometry (default false), simplify, limit (default 200)
-Returns: list of provinces, geometry included if includeGeometry=true
+Migration file
 
-GET /api/provinces/{id}
-Return full province details including geometry as GeoJSON
+DbContext updates
 
-GET /api/communes
-Parameters: province_id, search, includeGeometry, simplify, limit (default 300)
+Fluent API configurations
 
-GET /api/communes/{id}
-Return single commune including geometry in GeoJSON
+Any necessary annotations for Npgsql + NetTopologySuite
 
-GET /api/map/bbox
-Parameters: type = province or commune, bbox = xmin,ymin,xmax,ymax, simplify
-Return features intersecting bounding box
-
-SECTION: Technical Requirements
-
-Layering rules
-
-Domain layer
-
-Entities Province and Commune
-
-Geometry property must use NetTopologySuite Geometry
-
-Infrastructure
-
-EF Core configuration
-
-Map geometry column using: HasColumnType("geometry(MultiPolygon,4326)")
-
-Application
-
-DTOs: ProvinceDto, ProvinceGeoDto, CommuneDto, CommuneGeoDto
-
-GeoJSON serialization with NetTopologySuite IO GeoJsonWriter
-
-Mapping profiles
-
-Specification classes
-
-CQRS handlers
-
-API layer
-
-Minimal API endpoints under /api
-
-Validate inputs
-
-Convert Geometry to GeoJSON
-
-SECTION: Geometry to GeoJSON
-Use NetTopologySuite IO GeoJsonWriter
-Expected logic per entity:
-Instantiate GeoJsonWriter
-Call Write(geometry)
-Assign string result into DTO geometry field
-
-SECTION: Simplification
-Use ST_SimplifyPreserveTopology with tolerance from simplify parameter
-
-SECTION: Bounding Box Query
-Use geometry && ST_MakeEnvelope(xmin, ymin, xmax, ymax, 4326)
-
-SECTION: Acceptance Criteria
-
-API returns valid GeoJSON
-
-No EF entities leak to API
-
-Mapping handled through DTOs
-
-Correct use of Queries and Handlers
-
-Clean Architecture boundaries respected
-
-Minimal APIs created correctly
-
-PostgreSQL geometry loaded successfully
-
-Simplify and bbox work correctly
-
-Front-end Next.js consumes responses without modification
-
-SECTION: Cursor Task
-When executing this task, Cursor must generate all required files across Domain, Infrastructure, Application, and API layers.
-Strictly follow Clean Architecture structure.
-Ensure consistent GeoJSON formatting.
+Goal:
+Ensure backend can run with EF Core and is fully schema-synchronized with PostgreSQL/PostGIS without losing or modifying imported data.

--- a/tasks/Backend/LD-0003.md
+++ b/tasks/Backend/LD-0003.md
@@ -1,0 +1,152 @@
+TITLE: Build Backend APIs for Provinces & Communes (GeoJSON + PostGIS)
+
+SECTION: Goal
+Implement backend APIs required for mapping provinces and communes of Vietnam, using PostgreSQL + PostGIS and .NET 9 Clean Architecture (Jason Taylor template). These APIs will serve data for the Next.js front-end map, including boundaries stored as MultiPolygon SRID 4326.
+
+SECTION: Scope
+Cursor must generate full vertical slices including:
+
+Domain entities
+
+EF configurations
+
+Application DTOs
+
+CQRS Query + Handler
+
+Specification filters
+
+Mapping profiles
+
+Minimal API endpoints
+
+Geometry to GeoJSON serialization
+
+BBox queries
+
+Parameter validation
+
+SECTION: Database Tables
+
+TABLE provinces
+province_id (PK, string)
+name
+name_new
+administrative_center
+area_km2 (double)
+population (bigint)
+longitude (double)
+latitude (double)
+before_merger
+administrative_units
+geometry (MultiPolygon, SRID 4326)
+created_at
+updated_at
+
+TABLE communes
+commune_id (PK, string)
+province_id (FK → provinces)
+name
+name_new
+type
+area_km2 (double)
+population (bigint)
+longitude (double)
+latitude (double)
+before_merger
+geometry (MultiPolygon, SRID 4326)
+created_at
+updated_at
+
+SECTION: Required Endpoints
+
+GET /api/provinces
+Parameters: search, includeGeometry (default false), simplify, limit (default 200)
+Returns: list of provinces, geometry included if includeGeometry=true
+
+GET /api/provinces/{id}
+Return full province details including geometry as GeoJSON
+
+GET /api/communes
+Parameters: province_id, search, includeGeometry, simplify, limit (default 300)
+
+GET /api/communes/{id}
+Return single commune including geometry in GeoJSON
+
+GET /api/map/bbox
+Parameters: type = province or commune, bbox = xmin,ymin,xmax,ymax, simplify
+Return features intersecting bounding box
+
+SECTION: Technical Requirements
+
+Layering rules
+
+Domain layer
+
+Entities Province and Commune
+
+Geometry property must use NetTopologySuite Geometry
+
+Infrastructure
+
+EF Core configuration
+
+Map geometry column using: HasColumnType("geometry(MultiPolygon,4326)")
+
+Application
+
+DTOs: ProvinceDto, ProvinceGeoDto, CommuneDto, CommuneGeoDto
+
+GeoJSON serialization with NetTopologySuite IO GeoJsonWriter
+
+Mapping profiles
+
+Specification classes
+
+CQRS handlers
+
+API layer
+
+Minimal API endpoints under /api
+
+Validate inputs
+
+Convert Geometry to GeoJSON
+
+SECTION: Geometry to GeoJSON
+Use NetTopologySuite IO GeoJsonWriter
+Expected logic per entity:
+Instantiate GeoJsonWriter
+Call Write(geometry)
+Assign string result into DTO geometry field
+
+SECTION: Simplification
+Use ST_SimplifyPreserveTopology with tolerance from simplify parameter
+
+SECTION: Bounding Box Query
+Use geometry && ST_MakeEnvelope(xmin, ymin, xmax, ymax, 4326)
+
+SECTION: Acceptance Criteria
+
+API returns valid GeoJSON
+
+No EF entities leak to API
+
+Mapping handled through DTOs
+
+Correct use of Queries and Handlers
+
+Clean Architecture boundaries respected
+
+Minimal APIs created correctly
+
+PostgreSQL geometry loaded successfully
+
+Simplify and bbox work correctly
+
+Front-end Next.js consumes responses without modification
+
+SECTION: Cursor Task
+When executing this task, Cursor must generate all required files across Domain, Infrastructure, Application, and API layers.
+Strictly follow Clean Architecture structure.
+Ensure consistent GeoJSON formatting.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce `Province` and `Commune` entities with `MultiPolygon` geometry, enable Npgsql NetTopologySuite, configure EF mappings/DbSets, and add an idempotent migration to create PostGIS-backed tables.
> 
> - **Domain**
>   - Add `Province` and `Commune` entities using `NetTopologySuite` `MultiPolygon` geometry and relationships.
> - **Infrastructure / EF Core**
>   - Register `DbSet<Province>` and `DbSet<Commune>` in `ApplicationDbContext` and apply configurations.
>   - New configurations `ProvinceConfiguration` and `CommuneConfiguration` map columns and `geometry(MultiPolygon,4326)` with FK `ProvinceId` and index `IX_communes_province_id`.
>   - Update DI to use `UseNpgsql(..., o => o.UseNetTopologySuite())`.
>   - Add migration `20251127120000_AddProvincesAndCommunes` creating `provinces` and `communes` tables (IF NOT EXISTS) and index; `Down` is no-op.
>   - Update model snapshot to include spatial entities.
> - **Packages**
>   - Add `Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite` and `NetTopologySuite`; align `Npgsql.EntityFrameworkCore.PostgreSQL` to `9.0.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit baa8921f2543eea8836e540f253d6738c6a503fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->