### PR TITLE
feat(code): LD-0006 commit code base

### DIFF
--- a/.cursor/rules/interactive_feedback.mdc
+++ b/.cursor/rules/interactive_feedback.mdc
@@ -1,0 +1,41 @@
+---
+description: Enforce interactive feedback for all AI actions across all projects
+globs: ["**/*"]
+alwaysApply: true
+---
+
+# Global Interactive Feedback Rule
+
+To ensure safe and predictable AI behavior, all significant operations must use
+the interactive feedback MCP tool before proceeding.
+
+## 1. Before Asking Any Clarifying Question
+- The AI must call: `mcp_interactive-feedback-mcp_interactive_feedback`
+- Parameters:
+  - `project_directory`: Full absolute path of the workspace
+  - `summary`: Short explanation of what clarification is needed
+- Wait for the response before continuing.
+
+## 2. Before Completing Any Request (Writing, Editing, Refactoring)
+- The AI must again call: `mcp_interactive-feedback-mcp_interactive_feedback`
+- Include:
+  - `summary`: One-line description of what will be done or has been done
+- If the MCP response is empty → allowed to proceed automatically.
+- If feedback is provided → AI must revise according to the feedback.
+
+## 3. When Editing Files
+- AI must request confirmation *before modifying the workspace*.
+- This applies to:
+  - Creating files
+  - Editing existing files
+  - Deleting files
+  - Refactoring multiple files
+
+## 4. Examples of Correct Behavior
+
+### Before asking for more information:
+```json
+{
+  "project_directory": "/Users/Admin/Projects/MyApp",
+  "summary": "Need clarification about authentication flow"
+}

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,57 @@
+# Ignore everything by default
+*
+
+# Allow main source code folder
+!src/**
+
+# Allow solution files
+!*.sln
+!*.csproj
+!*.props
+!*.targets
+
+# Allow configurations used by development
+!.editorconfig
+!global.json
+
+# Ignore dev containers and environment setups
+.devcontainer/
+.azdo/
+.amazonqg/
+
+# Ignore artifacts / build output
+bin/
+obj/
+artifacts/
+out/
+dist/
+packages/
+
+# Ignore infrastructure folder (Terraform, scripts, IaC)
+infra/
+
+# Ignore template generators and scaffolding
+templates/
+
+
+# Ignore documentation folder (large and not needed for coding)
+docs/
+
+# Ignore version control metadata (safe)
+.git/
+.github/
+
+# Ignore secret files
+*.env
+*.env.*
+secrets/
+*.key
+*.pem
+*.pfx
+
+# Ignore log files
+*.log
+
+# Ignore OS/system files
+*.DS_Store
+Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -480,3 +480,7 @@ $RECYCLE.BIN/
 # Vim temporary swap files
 *.swp
 .azure
+/.amazonq/prompts
+/openspec
+/.openspec
+*.md

--- a/docs/sql Update/UpdateProvince_01122025.sql
+++ b/docs/sql Update/UpdateProvince_01122025.sql
@@ -1,0 +1,30 @@
+
+
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS unaccent;
+SELECT similarity('abc', 'abcd');
+
+
+
+ALTER TABLE provinces ADD COLUMN name_unaccent TEXT;
+
+
+CREATE FUNCTION update_unaccent_province()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.name_unaccent := unaccent(NEW.name);
+    RETURN NEW;
+END;
+$$;
+
+
+
+CREATE TRIGGER trg_unaccent_province
+BEFORE INSERT OR UPDATE ON provinces
+FOR EACH ROW
+EXECUTE FUNCTION update_unaccent_province();
+
+UPDATE provinces SET name_unaccent = unaccent(name);
+
+

--- a/src/Application/Common/Helpers/GeometryExtensions.cs
+++ b/src/Application/Common/Helpers/GeometryExtensions.cs
@@ -20,3 +20,10 @@ public static class GeometryExtensions
 
 
 
+
+
+
+
+
+
+

--- a/src/Application/Communes/Queries/GetCommunes/GetCommunesQueryValidator.cs
+++ b/src/Application/Communes/Queries/GetCommunes/GetCommunesQueryValidator.cs
@@ -19,3 +19,10 @@ public class GetCommunesQueryValidator : AbstractValidator<GetCommunesQuery>
 
 
 
+
+
+
+
+
+
+

--- a/src/Application/Geography/Dtos/CommuneGeoDto.cs
+++ b/src/Application/Geography/Dtos/CommuneGeoDto.cs
@@ -9,3 +9,10 @@ public class CommuneGeoDto : CommuneDto
 
 
 
+
+
+
+
+
+
+

--- a/src/Application/Geography/Dtos/ProvinceGeoDto.cs
+++ b/src/Application/Geography/Dtos/ProvinceGeoDto.cs
@@ -9,3 +9,10 @@ public class ProvinceGeoDto : ProvinceDto
 
 
 
+
+
+
+
+
+
+

--- a/src/Application/Geography/Specifications/CommuneSearchSpecification.cs
+++ b/src/Application/Geography/Specifications/CommuneSearchSpecification.cs
@@ -30,3 +30,10 @@ public sealed class CommuneSearchSpecification
 
 
 
+
+
+
+
+
+
+

--- a/src/Application/Geography/Specifications/ProvinceSearchSpecification.cs
+++ b/src/Application/Geography/Specifications/ProvinceSearchSpecification.cs
@@ -1,4 +1,6 @@
 using LotusDharma.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Npgsql.EntityFrameworkCore.PostgreSQL;
 
 namespace LotusDharma.Application.Geography.Specifications;
 
@@ -13,15 +15,16 @@ public sealed class ProvinceSearchSpecification
 
     public IQueryable<Province> Apply(IQueryable<Province> query)
     {
-        if (_search is null)
-        {
+        if (string.IsNullOrWhiteSpace(_search))
             return query;
-        }
 
-        var lowered = _search.ToLowerInvariant();
+        var keyword = _search!;
+
         return query.Where(p =>
-            p.Name.ToLower().Contains(lowered) ||
-            p.AdministrativeUnitsInfo.ToLower().Contains(lowered));
+                     EF.Functions.ILike(p.Name, $"%{keyword}%") ||
+                     EF.Functions.ILike(p.NameUnaccent ?? "", $"%{keyword}%") ||
+                     EF.Functions.TrigramsSimilarity(p.NameUnaccent ?? "", keyword) > 0.3
+                    );
     }
 }
 

--- a/src/Application/Map/Queries/GetCommunesByBoundingBox/GetCommunesByBoundingBoxQueryValidator.cs
+++ b/src/Application/Map/Queries/GetCommunesByBoundingBox/GetCommunesByBoundingBoxQueryValidator.cs
@@ -22,3 +22,10 @@ public class GetCommunesByBoundingBoxQueryValidator : AbstractValidator<GetCommu
 
 
 
+
+
+
+
+
+
+

--- a/src/Application/Map/Queries/GetProvincesByBoundingBox/GetProvincesByBoundingBoxQueryValidator.cs
+++ b/src/Application/Map/Queries/GetProvincesByBoundingBox/GetProvincesByBoundingBoxQueryValidator.cs
@@ -22,3 +22,10 @@ public class GetProvincesByBoundingBoxQueryValidator : AbstractValidator<GetProv
 
 
 
+
+
+
+
+
+
+

--- a/src/Application/Provinces/Queries/GetProvinces/GetProvincesQueryValidator.cs
+++ b/src/Application/Provinces/Queries/GetProvinces/GetProvincesQueryValidator.cs
@@ -19,3 +19,10 @@ public class GetProvincesQueryValidator : AbstractValidator<GetProvincesQuery>
 
 
 
+
+
+
+
+
+
+

--- a/src/Domain/Common/BaseEntity.cs
+++ b/src/Domain/Common/BaseEntity.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace LotusDharma.Domain.Common;
 

--- a/src/Domain/Entities/Province.cs
+++ b/src/Domain/Entities/Province.cs
@@ -28,8 +28,17 @@ public class Province
 
     public MultiPolygon? Geometry { get; set; }
     public List<double>? Bbox { get; set; }
+    public string? NameUnaccent { get; set; }
+
     public ICollection<Commune> Communes { get; set; } = new List<Commune>();
 }
+
+
+
+
+
+
+
 
 
 

--- a/src/Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/Data/ApplicationDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Reflection.Emit;
 using LotusDharma.Application.Common.Interfaces;
 using LotusDharma.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
@@ -34,6 +35,8 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
+        builder.HasPostgresExtension("pg_trgm");
+        builder.HasPostgresExtension("unaccent");
         builder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
     }
 }

--- a/src/Infrastructure/Data/Configurations/ProvinceConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/ProvinceConfiguration.cs
@@ -66,6 +66,11 @@ public class ProvinceConfiguration : IEntityTypeConfiguration<Province>
             .HasColumnName("geometry")
             .HasColumnType("geometry(MultiPolygon,4326)");
 
+
+        builder.Property(x => x.NameUnaccent)
+            .HasColumnName("name_unaccent")
+            .HasColumnType("text");
+
         builder.HasMany(x => x.Communes)
             .WithOne(x => x.Province)
             .HasForeignKey(x => x.ProvinceId)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable accent-insensitive and fuzzy province search via Postgres pg_trgm/unaccent, adding `name_unaccent` with trigger and EF mappings; minor tooling/ignore updates.
> 
> - **Search (Provinces)**
>   - Replace simple `Contains` filtering with Postgres-backed search: `EF.Functions.ILike`, `TrigramsSimilarity`, and fallback to `name_unaccent` in `ProvinceSearchSpecification`.
> - **Database/Schema**
>   - SQL migration script adds `name_unaccent` to `provinces`, creates trigger/function to populate it, backfills data.
>   - Enable `pg_trgm` and `unaccent` extensions (SQL script and `ApplicationDbContext`).
>   - Map `Province.NameUnaccent` to column `name_unaccent` in `ProvinceConfiguration`; add property to domain model.
> - **Tooling/Housekeeping**
>   - Add Cursor interactive feedback rule `.cursor/rules/interactive_feedback.mdc` and `.cursorignore`.
>   - Update `.gitignore` with additional paths and patterns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66896e6ec4f8e8951ad7936c9b987b46665fe3dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->